### PR TITLE
Add initial support for GeoPackage 1.1.

### DIFF
--- a/sqlite/src/ossimGpkgInfo.cpp
+++ b/sqlite/src/ossimGpkgInfo.cpp
@@ -75,13 +75,23 @@ std::ostream& ossimGpkgInfo::print(std::ostream& out) const
    // Check for empty filename.
    if (m_file.size())
    {
+      ossimKeywordlist kwl;
+
+      std::ifstream fileStream;
+      fileStream.open(m_file.c_str(), std::ios_base::in | std::ios_base::binary);
+      char APP_ID[5];
+      fileStream.seekg( 68, std::ios_base::beg );
+      fileStream.read(APP_ID, 4);
+      APP_ID[4] = '\0';
+      std::string appId(APP_ID);
+      kwl.addPair("gpkg.", "version", appId, true);
+      fileStream.close();
+
       sqlite3* db;
       
       int rc = sqlite3_open_v2( m_file.c_str(), &db, SQLITE_OPEN_READONLY, 0);
       if ( rc == SQLITE_OK )
       {
-         ossimKeywordlist kwl;
-
          // Get the gpkg_contents records:
          std::string tableName = "gpkg_contents";
          std::vector< ossimRefPtr<ossimGpkgDatabaseRecordBase> > records;

--- a/sqlite/src/ossimGpkgSpatialRefSysRecord.cpp
+++ b/sqlite/src/ossimGpkgSpatialRefSysRecord.cpp
@@ -394,7 +394,7 @@ void ossimGpkgSpatialRefSysRecord::saveState( ossimKeywordlist& kwl,
    key = "organization";
    kwl.addPair(myPref, key, m_organization, true);
    
-   key = "oganization_coordsys_id";
+   key = "organization_coordsys_id";
    value = ossimString::toString(m_organization_coordsys_id).string();
    kwl.addPair( myPref, key, value, true);
 

--- a/sqlite/src/ossimGpkgUtil.cpp
+++ b/sqlite/src/ossimGpkgUtil.cpp
@@ -50,16 +50,21 @@ bool ossim_gpkg::checkSignature(std::istream& in)
 bool ossim_gpkg::checkApplicationId(std::istream& in)
 {
    //---
-   // Check the application_id:
+   // Check the application_id.
+   // From GeoPackage 1.0:
    // Requirement 2: Every GeoPackage must contain 0x47503130 ("GP10" in ACII)
    // in the application id field of the SQLite database header to indicate a
    // GeoPackage version 1.0 file.
+   // From GeoPackage 1.1:
+   // A GeoPackage SHALL contain 0x47503131 ("GP11" in ASCII) in the application
+   // id field of the SQLite database header to indicate a GeoPackage version 1.1 file.
    //---
    bool result = false;
    char APP_ID[4];
    in.seekg( 68, std::ios_base::beg );
    in.read(APP_ID, 4);
-   if ( (APP_ID[0] == 'G') && (APP_ID[1] == 'P') && (APP_ID[2] == '1') && (APP_ID[3] == '0') )
+   if ( (APP_ID[0] == 'G') && (APP_ID[1] == 'P') && (APP_ID[2] == '1') &&
+       ( (APP_ID[3] == '0') || (APP_ID[3] == '1') ) )
    {
       result = true;
    }


### PR DESCRIPTION
This modifies the application version check to support both GP10 and GP11.

It also adds a dump variable to show which version we are dealing with.
