### PR TITLE
Fix openjpeg nitf reading

### DIFF
--- a/openjpeg/src/ossimOpjCommon.cpp
+++ b/openjpeg/src/ossimOpjCommon.cpp
@@ -124,7 +124,7 @@ static OPJ_BOOL ossim_opj_istream_seek(OPJ_OFF_T p_nb_bytes, void * p_user_data)
    {
       if ( usrStr->m_str )
       {
-         usrStr->m_str->seekg( p_nb_bytes, std::ios_base::cur );
+         usrStr->m_str->seekg( usrStr->m_offset + p_nb_bytes, std::ios_base::beg );
       }
    }
    return OPJ_TRUE;
@@ -140,7 +140,7 @@ static void ossim_opj_free_user_istream_data( void * p_user_data )
    usrStr = 0;
 }
 
-bool ossim::opj_decode( std::ifstream* in,
+bool ossim::opj_decode( std::istream* in,
                         const ossimIrect& rect,
                         ossim_uint32 resLevel,
                         ossim_int32 format, // OPJ_CODEC_FORMAT
@@ -175,7 +175,7 @@ bool ossim::opj_decode( std::ifstream* in,
       /* Set the length to avoid an assert */
       in->seekg(0, std::ios_base::end);
 
-      // Fix: length must be passed in for nift blocks.
+      // Fix: length must be passed in for NITF blocks.
       userStream->m_length = in->tellg();
 
       // Set back to front:
@@ -195,13 +195,11 @@ bool ossim::opj_decode( std::ifstream* in,
       opj_stream_set_skip_function(stream, ossim_opj_istream_skip);
       opj_stream_set_seek_function(stream, ossim_opj_istream_seek);
 
-      // Fix: length must be passed in for nift blocks.
-      opj_stream_set_user_data_length(stream, userStream->m_length);
-      
       opj_stream_set_user_data(stream, userStream,
                                ossim_opj_free_user_istream_data);
 
-      opj_stream_set_user_data_length(stream, userStream->m_length);
+      // Fix: length must be passed in for NITF blocks.
+      opj_stream_set_user_data_length(stream, userStream->m_length - userStream->m_offset);
 
       
       /* Set the default decoding parameters */
@@ -392,7 +390,7 @@ bool ossim::copyOpjImage( opj_image* image, ossimImageData* tile )
    
    if ( image && tile )
    {
-      if ( image->color_space == OPJ_CLRSPC_SRGB )
+      if ( image->color_space == OPJ_CLRSPC_SRGB || image->color_space == OPJ_CLRSPC_UNSPECIFIED )
       {
          const ossimScalarType SCALAR = tile->getScalarType();
          if ( SCALAR == OSSIM_UINT8 )

--- a/openjpeg/src/ossimOpjCommon.cpp
+++ b/openjpeg/src/ossimOpjCommon.cpp
@@ -397,6 +397,12 @@ bool ossim::copyOpjImage( opj_image* image, ossimImageData* tile )
          {
             status = ossim::copyOpjSrgbImage( ossim_uint8(0), image, tile );
          }
+         else if ( SCALAR == OSSIM_UINT9 || SCALAR == OSSIM_UINT10 || SCALAR == OSSIM_UINT11
+                   || SCALAR == OSSIM_UINT12 || SCALAR == OSSIM_UINT13 || SCALAR == OSSIM_UINT14
+		   || SCALAR == OSSIM_UINT15 || SCALAR == OSSIM_UINT16)
+	 {
+            status = ossim::copyOpjSrgbImage( ossim_uint16(0), image, tile );
+         }
          else
          {
             ossimNotify(ossimNotifyLevel_WARN)

--- a/openjpeg/src/ossimOpjCommon.h
+++ b/openjpeg/src/ossimOpjCommon.h
@@ -39,7 +39,7 @@ namespace ossim
    /** @brief Callback method for info. */
    void opj_info_callback(const char* msg, void* /* client_data */);
 
-   bool opj_decode( std::ifstream* in,
+   bool opj_decode( std::istream* in,
                     const ossimIrect& rect,
                     ossim_uint32 resLevel,
                     ossim_int32 format, // OPJ_CODEC_FORMAT

--- a/openjpeg/src/ossimOpjNitfReader.cpp
+++ b/openjpeg/src/ossimOpjNitfReader.cpp
@@ -62,6 +62,12 @@ bool ossimOpjNitfReader::canUncompress(
    return false;
 }
 
+void ossimOpjNitfReader::initializeSwapBytesFlag()
+{
+   // byte swapping is handled by openjpeg library.
+   theSwapBytesFlag = false;
+}
+
 void ossimOpjNitfReader::initializeReadMode()
 {
    // Initialize the read mode.

--- a/openjpeg/src/ossimOpjNitfReader.cpp
+++ b/openjpeg/src/ossimOpjNitfReader.cpp
@@ -13,13 +13,12 @@
 #include <openjpeg.h>
 
 #include <ossimOpjNitfReader.h>
+#include <ossimOpjCommon.h>
 #include <ossim/base/ossimCommon.h>
 #include <ossim/base/ossimException.h>
 #include <ossim/base/ossimTrace.h>
-#include <ossim/base/ossimEndian.h>
-#include <ossim/imaging/ossimTiffTileSource.h>
-#include <ossim/imaging/ossimImageDataFactory.h>
 #include <ossim/support_data/ossimNitfImageHeader.h>
+
 using namespace std;
 
 #ifdef OSSIM_ID_ENABLED
@@ -109,176 +108,48 @@ void ossimOpjNitfReader::initializeCompressedBuf()
 bool ossimOpjNitfReader::scanForJpegBlockOffsets()
 {
    const ossimNitfImageHeader* hdr = getCurrentImageHeader();
-   
+
    if ( !hdr || (theReadMode != READ_JPEG_BLOCK) || !theFileStr )
    {
       return false;
    }
 
-   theNitfBlockOffset.clear();
-   theNitfBlockSize.clear();
-
-   //---
-   // NOTE:
-   // SOC = 0xff4f Start of Codestream
-   // SOT = 0xff90 Start of tile
-   // SOD = 0xff93 Last marker in each tile
-   // EOC = 0xffd9 End of Codestream
-   //---
-   char c;
-
-   // Seek to the first block.
-   theFileStr->seekg(hdr->getDataLocation(), ios::beg);
-   if (theFileStr->fail())
-   {
-      return false;
-   }
-   
-   // Read the first two bytes and verify it is SOC; if not, get out.
-   theFileStr->get( c );
-   if (static_cast<ossim_uint8>(c) != 0xff)
-   {
-      return false;
-   }
-   theFileStr->get(c);
-   if (static_cast<ossim_uint8>(c) != 0x4f)
-   {
-      return false;
-   }
-
-   ossim_uint32 blockSize = 2;  // Read two bytes...
-
-   // Add the first offset.
-   // theNitfBlockOffset.push_back(hdr->getDataLocation());
-
-   // Find all the SOC markers.
-   while ( theFileStr->get(c) ) 
-   {
-      ++blockSize;
-      if (static_cast<ossim_uint8>(c) == 0xff)
-      {
-         if ( theFileStr->get(c) )
-         {
-            ++blockSize;
-
-            if (static_cast<ossim_uint8>(c) == 0x90) // At SOC marker...
-            {
-               std::streamoff pos = theFileStr->tellg();
-               theNitfBlockOffset.push_back(pos-2);
-            }
-            else if (static_cast<ossim_uint8>(c) == 0x93) // At EOC marker...
-            {
-               // Capture the size of this block.
-               theNitfBlockSize.push_back(blockSize);
-               blockSize = 0;
-            }
-         }
-      }
-   }
-
-   theFileStr->seekg(0, ios::beg);
-   theFileStr->clear();
-
-   // We should have the same amount of offsets as we do blocks...
-   ossim_uint32 total_blocks =
-      hdr->getNumberOfBlocksPerRow()*hdr->getNumberOfBlocksPerCol();
-   
-   if (theNitfBlockOffset.size() != total_blocks)
-   {
-      if (traceDebug())
-      {
-         ossimNotify(ossimNotifyLevel_WARN)
-            << "DEBUG:"
-            << "\nBlock offset count wrong!"
-            << "\nblocks:  " << total_blocks
-            << "\noffsets:  " << theNitfBlockOffset.size()
-            << std::endl;
-      }
-      
-      return false;
-   }
-   if (theNitfBlockSize.size() != total_blocks)
-   {
-      if (traceDebug())
-      {
-         ossimNotify(ossimNotifyLevel_WARN)
-            << "DEBUG:"
-            << "\nBlock size count wrong!"
-            << "\nblocks:  " << total_blocks
-            << "\nblock size array:  " << theNitfBlockSize.size()
-            << std::endl;
-      }
-
-      return false;
-   }
-
+   // openjpeg handles scanning for blocks
    return true;
 }
+
 
 bool ossimOpjNitfReader::uncompressJpegBlock(ossim_uint32 x,
                                              ossim_uint32 y)
 {
-   ossim_uint32 blockNumber = getBlockNumber(ossimIpt(x,y));
-
-   if (traceDebug())
-   {
-      ossimNotify(ossimNotifyLevel_DEBUG)
-         << "ossimNitfTileSource::uncompressJpegBlock DEBUG:"
-         << "\nblockNumber:  " << blockNumber
-         << "\noffset to block: " << theNitfBlockOffset[blockNumber]
-         << "\nblock size: " << theNitfBlockSize[blockNumber]
-         << std::endl;
-   }
-   
-   // Seek to the block.
-   theFileStr->seekg(theNitfBlockOffset[blockNumber], ios::beg);
-
-   //---
-   // Get a buffer to read the compressed block into.  If all the blocks are
-   // the same size this will be theCompressedBuf; else we will make our own.
-   //---
-   ossim_uint8* compressedBuf = &theCompressedBuf.front();
-   if (!compressedBuf)
-   {
-      compressedBuf = new ossim_uint8[theNitfBlockSize[blockNumber]];
-   }
-
-
-   // Read the block into memory.  We could store this
-   if (!theFileStr->read((char*)compressedBuf, theNitfBlockSize[blockNumber]))
-   {
-      theFileStr->clear();
-      ossimNotify(ossimNotifyLevel_FATAL)
-         << "ossimNitfTileSource::loadBlock Read Error!"
-         << "\nReturning error..." << endl;
-      theErrorStatus = ossimErrorCodes::OSSIM_ERROR;
-      delete [] compressedBuf;
-      compressedBuf = 0;
-      return false;
-   }
-
-   try
-   {
-      //theCacheTile = decoder.decodeBuffer(compressedBuf,
-      //                                    theNitfBlockSize[blockNumber]);
-   }
-   catch (const ossimException& e)
-   {
-      ossimNotify(ossimNotifyLevel_FATAL)
-         << e.what() << std::endl;
-      theErrorStatus = ossimErrorCodes::OSSIM_ERROR;
-   }
-
-   // If theCompressedBuf is null that means we allocated the compressedBuf.
-   if (theCompressedBuf.size() == 0)
-   {
-      delete [] compressedBuf;
-      compressedBuf = 0;
-   }
-   
-   if (theErrorStatus == ossimErrorCodes::OSSIM_ERROR)
+   const ossimNitfImageHeader *hdr = getCurrentImageHeader();
+   if (!hdr)
    {
       return false;
    }
+   ossim_uint32 numX = theCacheSize.x;
+   ossim_uint32 numY = theCacheSize.y;
+   ossim_uint32 blockX = x / numX;
+   ossim_uint32 blockY = y / numY;
+
+   ossimIrect rect(ossimIpt(blockX * numX, blockY * numY),
+                   ossimIpt((blockX + 1) * numX - 1, (blockY + 1) * numY - 1));
+
+   std::streamoff offset = hdr->getDataLocation();
+   theFileStr->seekg(offset, ios::beg);
+   ossim_int32 format = ossim::getCodecFormat(theFileStr.get());
+   if (format == OPJ_CODEC_UNKNOWN)
+   {
+      ossimNotify(ossimNotifyLevel_WARN)
+          << "ossimOpjNitfReader::uncompressJpegBlock WARNING!\n"
+          << "Unknown openjpeg codec\n";
+      return false;
+   }
+
+   if (ossim::opj_decode(theFileStr.get(), rect, 0, format, offset, theCacheTile.get()) == false)
+   {
+       return false;
+   }
+
    return true;
 }

--- a/openjpeg/src/ossimOpjNitfReader.h
+++ b/openjpeg/src/ossimOpjNitfReader.h
@@ -46,15 +46,13 @@ protected:
    virtual void initializeCompressedBuf();
 
    /**
-    * @brief scans the file storing in offsets in "theNitfBlockOffset" and
-    * block sizes in "theNitfBlockSize".
-    * @return true on success, false on error.  This checks for arrays being
-    * the same size as number of blocks.
+    * @brief does nothing as block offsets are scanned by openjpeg, not us
+    * @return true on success, false on error.
     */
    virtual bool scanForJpegBlockOffsets();
 
    /**
-    * @brief Uncompresses a jpeg block using the jpeg-6b library.
+    * @brief Uncompresses a jpeg block using the openjpeg library.
     * @param x sample location in image space.
     * @param y line location in image space.
     * @return true on success, false on error.

--- a/openjpeg/src/ossimOpjNitfReader.h
+++ b/openjpeg/src/ossimOpjNitfReader.h
@@ -36,6 +36,11 @@ protected:
    virtual bool canUncompress(const ossimNitfImageHeader* hdr) const;
 
    /**
+    * Initializes the data member "theSwapBytesFlag" from the current entry.
+    */
+   virtual void initializeSwapBytesFlag();
+
+   /**
     * Initializes the data member "theReadMode" from the current entry.
     */
    virtual void initializeReadMode();


### PR DESCRIPTION
Existing implementation didn't work at all: https://github.com/ossimlabs/ossim-plugins/blob/b85060056eadbe86d87467789ae27e697773c339/openjpeg/src/ossimOpjNitfReader.cpp#L262

Tested on https://download.osgeo.org/gdal/data/nitf/jpeg2000/p0_01a.ntf as well as NTM imagery.