### PR TITLE
Fix S3 stream reading past end of buffer.

### DIFF
--- a/aws/src/ossimS3StreamBuffer.cpp
+++ b/aws/src/ossimS3StreamBuffer.cpp
@@ -427,7 +427,8 @@ std::streamsize ossim::S3StreamBuffer::xsgetn(char_type *s, std::streamsize n)
       // get each bloc
       if (currentAbsolutePosition >= 0)
       {
-         ossim_int64 delta = m_blockInfo.getStartByte() + (egptr() - gptr()); //(m_blockInfo.getEndByte() - m_blockInfo.getCurrentByte()); //(endOffset - m_currentBlockPosition)+1;
+         // number of bytes remaining in the current block
+         ossim_int64 delta = egptr() - gptr();
 
          if (delta <= bytesNeedToRead)
          {


### PR DESCRIPTION
The S3 stream reads blocks of data in at a time and hands them out for individual read requests.  The code was incorrectly computing the number of bytes remaining in the current block and was reading past the end of the block instead of triggering the fetch of the next block.