### PR TITLE
added cast to get to compile

### DIFF
--- a/gdal/src/ossimGdalTiledDataset.cpp
+++ b/gdal/src/ossimGdalTiledDataset.cpp
@@ -473,7 +473,7 @@ void GDALRegister_MEMTiled()
                                    "In Memory Raster OSSIM tile bridge" );
 
         poDriver->pfnOpen   = MEMDataset::Open;
-        poDriver->pfnCreate = MEMDataset::Create;
+        poDriver->pfnCreate = (GDALDataset *(*)(const char *, int, int, int, GDALDataType, char **))MEMDataset::Create;
 
         GetGDALDriverManager()->RegisterDriver( poDriver );
     }


### PR DESCRIPTION
I had to add as cast to get this to compile w/newer version of gdal.   My C++ is a little rusty and this seems dangerous so,  is this the right thing todo?   Should I be using static or dynamic cast instead?   