### PR TITLE
Tightened GDAL/OGR integration by checking extent/IO return codes and…

### DIFF
--- a/gdal/src/ossimGdalOgrVectorAnnotation.cpp
+++ b/gdal/src/ossimGdalOgrVectorAnnotation.cpp
@@ -45,6 +45,7 @@
 #include <ossim/support_data/ossimFgdcXmlDoc.h>
 #include <ogr_api.h>
 #include <sstream>
+#include <cpl_conv.h>
 
 using namespace std;
 
@@ -425,8 +426,14 @@ bool ossimGdalOgrVectorAnnotation::open(const ossimFilename& file)
                
                if(i == 0)
                {
-                  layer->GetExtent(&theBoundingExtent, true);
-                  if(mapProj)
+                  const OGRErr extentStatus = layer->GetExtent(&theBoundingExtent, true);
+                  if(extentStatus != OGRERR_NONE)
+                  {
+                     ossimNotify(ossimNotifyLevel_WARN)
+                        << "ossimGdalOgrVectorAnnotation: failed to fetch layer extent (error code: "
+                        << extentStatus << ")" << std::endl;
+                  }
+                  else if(mapProj)
                   {
                      if (layer->GetSpatialRef())
                      {
@@ -467,8 +474,14 @@ bool ossimGdalOgrVectorAnnotation::open(const ossimFilename& file)
                else
                {
                   OGREnvelope extent;
-                  layer->GetExtent(&extent, true);
-                  if(mapProj)
+                  const OGRErr extentStatus = layer->GetExtent(&extent, true);
+                  if(extentStatus != OGRERR_NONE)
+                  {
+                     ossimNotify(ossimNotifyLevel_WARN)
+                        << "ossimGdalOgrVectorAnnotation: failed to fetch extent for layer index "
+                        << i << " (error code: " << extentStatus << ")" << std::endl;
+                  }
+                  else if(mapProj)
                   {
                      ossimDrect rect(extent.MinX,
                                      extent.MaxY,
@@ -1312,8 +1325,15 @@ void ossimGdalOgrVectorAnnotation::initializeTables()
             ossimMapProjection* mapProj = PTR_CAST(ossimMapProjection, proj.get());
             
             layer->ResetReading();
-            layer->GetExtent(&extent, true);
+            const OGRErr extentStatus = layer->GetExtent(&extent, true);
             layer->ResetReading();
+            if(extentStatus != OGRERR_NONE)
+            {
+               ossimNotify(ossimNotifyLevel_WARN)
+                  << "ossimGdalOgrVectorAnnotation: failed to fetch extent while loading features (error code: "
+                  << extentStatus << ")" << std::endl;
+               continue;
+            }
 
             OGRFeature* feature = NULL;
             if(mapProj)
@@ -1586,7 +1606,7 @@ ossimProjection* ossimGdalOgrVectorAnnotation::createProjFromReference(OGRSpatia
       ossimNotify(ossimNotifyLevel_DEBUG) << "wktString === " << wktString << std::endl;
       ossimNotify(ossimNotifyLevel_DEBUG) << "KWL === " << kwl << std::endl;
    }
-   OGRFree(wktString);
+   CPLFree(wktString);
    if(traceDebug())
    {
       ossimNotify(ossimNotifyLevel_DEBUG) << "ossimGdalOgrVectorAnnotation::createProjFromReference:   returning........" << std::endl;

--- a/gdal/src/ossimGdalWriter.cpp
+++ b/gdal/src/ossimGdalWriter.cpp
@@ -30,6 +30,7 @@
 #include <ossim/projection/ossimProjectionFactoryRegistry.h>
 #include <ossim/vpfutil/set.h>
 #include <cmath>
+#include <cstdio>
 #include <iterator>
 #include <sstream>
 using namespace std;
@@ -288,8 +289,16 @@ void ossimGdalWriter::checkColorLut()
                ossimImageChain* imageChain = PTR_CAST(ossimImageChain, imageChains[j].get());
                if (imageChain)
                {
-                  ossimConnectableObject::ConnectableObjectList imageHandlers =
-                     imageChain->findAllObjectsOfType(STATIC_TYPE_INFO(ossimImageHandler), false);
+                  ossimConnectableObject::ConnectableObjectList imageHandlers;
+                  const ossimImageChain::ConnectableObjectList& chainChildren = imageChain->imageChainList();
+                  for (ossim_uint32 childIdx = 0; childIdx < chainChildren.size(); ++childIdx)
+                  {
+                     const ossimRefPtr<ossimConnectableObject>& child = chainChildren[childIdx];
+                     if (child.valid() && child->canCastTo(STATIC_TYPE_INFO(ossimImageHandler)))
+                     {
+                        imageHandlers.push_back(child);
+                     }
+                  }
 
                   for (ossim_uint32 h= 0; h < imageHandlers.size(); h++)
                   {
@@ -495,10 +504,10 @@ bool ossimGdalWriter::writeFile()
                      if ( maxPix > 0.0 && minPix < maxPix )
                      {
                         char szValue[128];
-                        sprintf( szValue, "%.14g", minPix );
+                        std::snprintf( szValue, sizeof(szValue), "%.14g", minPix );
                         GDALSetMetadataItem( aBand, "STATISTICS_MINIMUM", szValue, 0 );
 
-                        sprintf( szValue, "%.14g", maxPix );
+                        std::snprintf( szValue, sizeof(szValue), "%.14g", maxPix );
                         GDALSetMetadataItem( aBand, "STATISTICS_MAXIMUM", szValue, 0 );
                      }
                   }
@@ -530,7 +539,7 @@ bool ossimGdalWriter::writeFile()
 
                   if(aBand)
                   {
-                     GDALRasterIO( aBand,
+                     const CPLErr ioStatus = GDALRasterIO( aBand,
                         GF_Write,
                         offset.x,
                         offset.y,
@@ -542,6 +551,13 @@ bool ossimGdalWriter::writeFile()
                         gdalType,
                         0,
                         0);
+                     if (ioStatus != CE_None)
+                     {
+                        ossimNotify(ossimNotifyLevel_WARN)
+                           << "ossimGdalWriter: GDALRasterIO write failed for band "
+                           << (band + 1) << " (error code: " << ioStatus << ")" << std::endl;
+                        break;
+                     }
                   }
 
                   ++tileNumber;

--- a/gdal/src/ossimOgcWktTranslator.cpp
+++ b/gdal/src/ossimOgcWktTranslator.cpp
@@ -19,6 +19,7 @@
 
 #include <cstdio>
 #include <gdal.h>
+#include <cpl_conv.h>
 #include <geovalues.h>
 
 #include "ossimOgcWktTranslator.h"
@@ -539,7 +540,7 @@ ossimString ossimOgcWktTranslator::fromOssimKwl(const ossimKeywordlist &kwl,
    if(exportString)
    {
       wktString = exportString;
-      OGRFree(exportString);
+      CPLFree(exportString);
    }
 
    return wktString;
@@ -1080,4 +1081,3 @@ ossimString ossimOgcWktTranslator::ossimToWktProjection(const ossimString& datum
    }
    return result;
 }
-

--- a/gdal/src/ossimOgrInfo.cpp
+++ b/gdal/src/ossimOgrInfo.cpp
@@ -16,6 +16,7 @@
 #include <ossim/base/ossimKeywordlist.h>
 
 #include <ogr_api.h>
+#include <gdal.h>
 
 #include <fstream>
 #include <iostream>
@@ -95,7 +96,7 @@ ossimOgrInfo::~ossimOgrInfo()
 {
   if (m_ogrDatasource != NULL)
   {
-    OGRDataSource::DestroyDataSource(m_ogrDatasource);
+    GDALClose(reinterpret_cast<GDALDatasetH>(m_ogrDatasource));
     m_ogrDatasource = 0;
   }
 }
@@ -104,7 +105,7 @@ bool ossimOgrInfo::open(const ossimFilename& file)
 {
    if ( m_ogrDatasource )
    {
-      OGRDataSource::DestroyDataSource(m_ogrDatasource);
+      GDALClose(reinterpret_cast<GDALDatasetH>(m_ogrDatasource));
       m_ogrDatasource = 0;
    }
 
@@ -123,7 +124,7 @@ bool ossimOgrInfo::open(const ossimFilename& file)
 
       if ( !m_ogrDriver ) 
       {
-         OGRDataSource::DestroyDataSource( m_ogrDatasource );
+         GDALClose(reinterpret_cast<GDALDatasetH>(m_ogrDatasource));
          m_ogrDatasource = 0;
       }
    }

--- a/gdal/src/ossimOgrVectorTileSource.cpp
+++ b/gdal/src/ossimOgrVectorTileSource.cpp
@@ -27,6 +27,7 @@
 #include <ossim/projection/ossimEquDistCylProjection.h>
 
 #include <ogr_api.h>
+#include <cpl_conv.h>
 
 RTTI_DEF1(ossimOgrVectorTileSource,
           "ossimOgrVectorTileSource",
@@ -150,7 +151,15 @@ bool ossimOgrVectorTileSource::open()
                
                if (layer)
                {
-                  layer->GetExtent(&theBoundingExtent, true);
+                  const OGRErr extentStatus = layer->GetExtent(&theBoundingExtent, true);
+                  if (extentStatus != OGRERR_NONE)
+                  {
+                     ossimNotify(ossimNotifyLevel_WARN)
+                        << MODULE
+                        << " failed to fetch layer extent for layer " << i
+                        << " (error code: " << extentStatus << ")" << std::endl;
+                     continue;
+                  }
                   
                   ossimRefPtr<ossimProjection> proj = createProjFromReference(layer->GetSpatialRef());
                   ossimRefPtr<ossimImageGeometry> imageGeometry = 0;
@@ -477,7 +486,7 @@ ossimProjection* ossimOgrVectorTileSource::createProjFromReference(OGRSpatialRef
       ossimNotify(ossimNotifyLevel_DEBUG) << "wktString === " << wktString << std::endl;
       ossimNotify(ossimNotifyLevel_DEBUG) << "KWL === " << kwl << std::endl;
    }
-   OGRFree(wktString);
+   CPLFree(wktString);
    if(traceDebug())
    {
       ossimNotify(ossimNotifyLevel_DEBUG) << "ossimOgrVectorTileSource::createProjFromReference:   returning........" << std::endl;

--- a/web/src/ossimCurlHttpRequest.cpp
+++ b/web/src/ossimCurlHttpRequest.cpp
@@ -120,7 +120,7 @@ int ossimCurlHttpRequest::curlWriteResponseHeader(void *buffer, size_t size, siz
 
 ossim_int64 ossimCurlHttpRequest::getContentLength()const
 {
-   double contentLength=-1;
+   curl_off_t contentLength = -1;
    curl_easy_reset(m_curl);
    clearLastError();
    ossimString urlString = getUrl().toString();
@@ -163,7 +163,7 @@ ossim_int64 ossimCurlHttpRequest::getContentLength()const
    if(result)
    {
       response->convertHeaderStreamToKeywordlist();
-      rc = curl_easy_getinfo(m_curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &contentLength);
+      rc = curl_easy_getinfo(m_curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &contentLength);
    //if(rc>=1) contentLength = -1;
    // response->convertHeaderStreamToKeywordlist();
    //std::cout << response->headerKwl() << "\n";
@@ -174,7 +174,7 @@ ossim_int64 ossimCurlHttpRequest::getContentLength()const
       //std::cout << curl_easy_strerror((CURLcode)rc) << std::endl;
    }
 
-   return static_cast<ossim_int64> (contentLength);
+   return static_cast<ossim_int64>(contentLength);
 }
 
 void ossimCurlHttpRequest::setDefaultSSL(CURL* curl)const


### PR DESCRIPTION
… logging failures before using the data (ossim-plugins/gdal/src/ossimGdalOgrVectorAnnotation.cpp:427, ossim-plugins/gdal/src/ossimGdalWriter.cpp:540). Updated resource-management to the CPL memory/close helpers expected by newer GDAL releases (ossim-plugins/gdal/src/ossimOgcWktTranslator.cpp:539, ossim-plugins/gdal/src/ossimOgrInfo.cpp:95). Modernized ancillary code by replacing child scans with explicit traversal and upgrading libcurl calls to the 64-bit download-length API (ossim-plugins/gdal/src/ossimGdalWriter.cpp:292, ossim-plugins/web/src/ossimCurlHttpRequest.cpp:121).