### PR TITLE
fix: migrate the ATP plugin to OpenCV 4

### DIFF
--- a/atp/src/AtpOpenCV.h
+++ b/atp/src/AtpOpenCV.h
@@ -8,7 +8,12 @@
 #define AtpOpenCV_HEADER
 
 #include <ossim/imaging/ossimImageData.h>
-#include <opencv/cv.h>
+// OpenCV 4 removed the legacy <opencv/cv.h> umbrella header. The C API this file
+// uses (IplImage, cvCreateImage, cvCornerHarris, cvShowImage, ...) now lives in
+// the per-module *_c.h headers.
+#include <opencv2/core/core_c.h>
+#include <opencv2/imgproc/imgproc_c.h>
+#include <opencv2/highgui/highgui_c.h>
 #include <memory>
 
 class ossimImageData;

--- a/atp/src/ossimDescriptorSource.cpp
+++ b/atp/src/ossimDescriptorSource.cpp
@@ -11,7 +11,22 @@
 #include "AtpGenerator.h"
 #include <ossim/imaging/ossimImageDataFactory.h>
 
-#include <opencv2/xfeatures2d.hpp>
+// xfeatures2d ships only with opencv_contrib. Use it when present; otherwise fall
+// back to the main-module cv::SIFT, which OpenCV moved out of contrib in 4.4.
+#if defined(__has_include)
+#  if __has_include(<opencv2/xfeatures2d.hpp>)
+#    include <opencv2/xfeatures2d.hpp>
+#    define ATP_HAVE_XFEATURES2D 1
+#  endif
+#endif
+
+#if (CV_VERSION_MAJOR > 4) || (CV_VERSION_MAJOR == 4 && CV_VERSION_MINOR >= 4)
+#  define ATP_SIFT cv::SIFT
+#elif defined(ATP_HAVE_XFEATURES2D)
+#  define ATP_SIFT cv::xfeatures2d::SIFT
+#else
+#  error "SIFT unavailable: need OpenCV >= 4.4 or opencv_contrib"
+#endif
 
 using namespace std;
 
@@ -143,9 +158,18 @@ ossimRefPtr<ossimImageData> ossimDescriptorSource::getTile(const ossimIrect& til
    else if(descriptorType == "ORB")
       detector = cv::ORB::create();
    else if(descriptorType == "SURF")
+   {
+#ifdef ATP_HAVE_XFEATURES2D
       detector = cv::xfeatures2d::SURF::create();
+#else
+      CWARN << MODULE << " WARNING: SURF requires opencv_contrib built with the "
+               "nonfree modules (port install opencv4 +contrib +nonfree). "
+               "Using SIFT instead.\n";
+      detector = ATP_SIFT::create();
+#endif
+   }
    else if(descriptorType == "SIFT")
-      detector = cv::xfeatures2d::SIFT::create();
+      detector = ATP_SIFT::create();
    else
    {
       CWARN << MODULE << " WARNING: No such descriptor as " << descriptorType << "\n";


### PR DESCRIPTION
AtpOpenCV.h included <opencv/cv.h>, the OpenCV 1.x-era umbrella header that OpenCV 4 removed. The build fails at that include with any OpenCV 4-only installation. Replaced with the per-module C headers that still carry the C API this plugin uses:

    opencv2/core/core_c.h        IplImage, cvCreateImage, cvConvert,
                                 cvReleaseImage, cvAlloc, cvGetSize
    opencv2/imgproc/imgproc_c.h  cvCornerHarris, cvGoodFeaturesToTrack,
                                 cvMatchTemplate
    opencv2/highgui/highgui_c.h  cvNamedWindow, cvShowImage, cvWaitKey

ossimDescriptorSource.cpp included opencv2/xfeatures2d.hpp unconditionally. That header is part of opencv_contrib, which a stock OpenCV 4 does not provide, so the include alone breaks the build. It is now guarded with __has_include, and SIFT is taken from the main module, where OpenCV moved it in 4.4. SURF still requires contrib plus a nonfree build; without it the code now warns at runtime and falls back to SIFT rather than failing to compile. AKAZE, KAZE and ORB were never affected.

Worth noting for anyone debugging a related failure: FindOpenCV.cmake searches /opt/local/include before /opt/local/include/opencv4, so an OpenCV 3 present alongside OpenCV 4 silently wins for the whole build and masks this. That is how the legacy header kept resolving.

Verified with a from-scratch configure (CMake cache removed) against opencv4 4.9.0 on macOS/MacPorts: the ATP plugin builds clean, as do the other twelve plugins.

AtpOpenCV.h is CRLF; line endings are preserved.


Claude-Session: https://claude.ai/code/session_018swUP8pmvxKYsug9Tc6z2z