### PR TITLE
fix: guard against an empty descriptor, and an int-to-float narrowing

### DIFF
--- a/atp/src/ossimDescriptorSource.cpp
+++ b/atp/src/ossimDescriptorSource.cpp
@@ -176,6 +176,16 @@ ossimRefPtr<ossimImageData> ossimDescriptorSource::getTile(const ossimIrect& til
       return m_tile;
    }
 
+   // Every branch above either assigns a detector or returns, but create() can
+   // still hand back an empty Ptr for a type the OpenCV build does not carry.
+   // Without this, the dereference below is a null deref.
+   if (detector.empty())
+   {
+      CWARN << MODULE << " WARNING: Descriptor " << descriptorType
+            << " is not available in this OpenCV build\n";
+      return m_tile;
+   }
+
 #if 1
    detector->detectAndCompute(queryImg, cv::noArray(), kpA, desA);
    detector->detectAndCompute(trainImg, cv::noArray(), kpB, desB);
@@ -280,7 +290,7 @@ ossimRefPtr<ossimImageData> ossimDescriptorSource::getTile(const ossimIrect& til
       matcher->knnMatch(desA, desB, matches, k);
    }
 
-   float minDistance = INT_MAX;
+   float minDistance = static_cast<float>(INT_MAX);
    float maxDistance = 0;
 
    // Find the highest distance to compute the relative confidence of each match


### PR DESCRIPTION
Two small fixes to ossimDescriptorSource that predate the OpenCV 4 migration and were not carried by it.

cv::*::create() can return an empty Ptr for a descriptor type the OpenCV build does not carry. The if/else chain either assigns a detector or returns, so the empty case fell through to detector->detectAndCompute() and dereferenced null. It now warns and returns the tile, matching how an unrecognised descriptor name is already handled a few lines above.

minDistance is a float initialised from INT_MAX, an implicit int-to-float narrowing that is not exactly representable and warns under -Wconversion. Made explicit; the value is a sentinel immediately replaced by the first comparison, so behaviour is unchanged.


Claude-Session: https://claude.ai/code/session_018swUP8pmvxKYsug9Tc6z2z